### PR TITLE
Made a small change to the routes endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ export CAPI_ROUTE_GUID=$(cf curl /v2/routes | jq -r '.resources[] | select(.enti
 
 ### View pilot API results
 ```sh
-curl localhost:8080/v1/routes/http_proxy/x/router~x~x~x
+curl localhost:8080/v1/routes/[LISTENER PORT NUMBER: 80/443]/x/router~x~x~x
 ```
 
 and


### PR DESCRIPTION
I realized that the right syntax for calling the routes endpoint is 

```
curl localhost:8080/v1/routes/80/x/router~x~x~x
{
  "validate_clusters": true,
  "virtual_hosts": []
 }

curl localhost:8080/v1/routes/443/x/router~x~x~x
{
  "validate_clusters": true,
  "virtual_hosts": []
 }
```