### PR TITLE
pilot log level can now be set

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,8 @@ import (
 	"code.cloudfoundry.org/copilot/config"
 	"code.cloudfoundry.org/copilot/testhelpers"
 	"code.cloudfoundry.org/durationjson"
+	"istio.io/istio/pkg/log"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -35,6 +37,7 @@ var _ = Describe("Config", func() {
 			ServerKeyPath:                   "some-key-path",
 			VIPCIDR:                         "127.128.0.0/9",
 			MCPConvergeInterval:             durationjson.Duration(10 * time.Second),
+			PilotLogLevel:                   log.FatalLevel,
 			BBS: &config.BBSConfig{
 				ServerCACertPath: "some-ca-path",
 				ClientCertPath:   "some-cert-path",

--- a/config/config_test.json
+++ b/config/config_test.json
@@ -7,6 +7,7 @@
   "ServerKeyPath":                   "some-key-path",
   "VIPCIDR":                         "127.128.0.0/9",
   "MCPConvergeInterval":             "10s",
+  "PilotLogLevel":                   "fatal",
   "BBS": {
     "ServerCACertPath": "some-ca-path",
     "ClientCertPath":   "some-cert-path",

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -17,11 +17,13 @@ import (
 	"code.cloudfoundry.org/copilot/testhelpers"
 	"code.cloudfoundry.org/durationjson"
 	"github.com/gogo/protobuf/proto"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/log"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Copilot", func() {
@@ -151,6 +153,7 @@ var _ = Describe("Copilot", func() {
 			ServerKeyPath:                   copilotTLSFiles.ServerKey,
 			VIPCIDR:                         "127.128.0.0/9",
 			MCPConvergeInterval:             durationjson.Duration(10 * time.Millisecond),
+			PilotLogLevel:                   log.FatalLevel,
 			BBS: &config.BBSConfig{
 				ServerCACertPath: bbsTLSFiles.ServerCA,
 				ClientCertPath:   bbsTLSFiles.ClientCert,


### PR DESCRIPTION
- we are using a pilot library, and thus, we need to be
able to set it's log level.
- this allows for passing of log level as a string
which is then transformed into the proper pilot
type.
- added code for both marshaling and unmarshaling
type transformation. Without both it would have
meant rewriting all of the test code centered
around Save in the config package.